### PR TITLE
WIP Add nice NetworkOperations with additional flexibility

### DIFF
--- a/PeakNetwork/NetworkOperation.swift
+++ b/PeakNetwork/NetworkOperation.swift
@@ -168,12 +168,48 @@ open class DynamicRequestableOperation<D: Decodable>: NetworkOperation<(D, HTTPU
 
 /// A subclass of `NetworkOperation`.
 /// `RequestableInputOperation` will take a `Requestable` input, call it, and attempt to parse the response into a `Decodable` type.
-public class RequestableInputOperation<D: Decodable>: NetworkOperation<(D, HTTPURLResponse)>, ConsumesResult {
+public class RequestableInputOperation<D: Decodable>: NetworkOperation<D>, ConsumesResult {
     
     public var input: Result<Requestable> = Result { throw ResultError.noResult }
     private let decoder: JSONDecoder
     
     /// Create a new `RequestableInputOperation`, parsing the response to a list of the given generic type.
+    ///
+    /// - Parameters:
+    ///   - session: The `JSONDecoder` to use when decoding the response data (optional).
+    ///   - session: The `URLSession` in which to perform the fetch (optional).
+    public init(decoder: JSONDecoder = JSONDecoder(), session: Session = URLSession.shared) {
+        self.decoder = decoder
+        super.init(with: session)
+    }
+    
+    public override func createTask(in session: Session) -> URLSessionTask? {
+        switch input {
+        case .success(let requestable):
+            return session.dataTask(with: requestable.request, decoder: decoder) { [weak self] (result: Result<(D, HTTPURLResponse)>) in
+                guard let strongSelf = self else { return }
+                strongSelf.output = Result {
+                    let (decoded, _) = try result.resolve()
+                    return decoded
+                }
+                strongSelf.finish()
+            }
+        case .failure(let error):
+            output = Result { throw error }
+            finish()
+            return nil
+        }
+    }
+}
+
+/// A subclass of `NetworkOperation`.
+/// `RequestableInputResponseOperation` will take a `Requestable` input, call it, and attempt to parse the response into a `Decodable` type.
+public class RequestableInputResponseOperation<D: Decodable>: NetworkOperation<(D, HTTPURLResponse)>, ConsumesResult {
+    
+    public var input: Result<Requestable> = Result { throw ResultError.noResult }
+    private let decoder: JSONDecoder
+    
+    /// Create a new `RequestableInputResponseOperation`, parsing the response to a list of the given generic type.
     ///
     /// - Parameters:
     ///   - session: The `JSONDecoder` to use when decoding the response data (optional).
@@ -198,6 +234,7 @@ public class RequestableInputOperation<D: Decodable>: NetworkOperation<(D, HTTPU
         }
     }
 }
+
 
 /// A subclass of `NetworkOperation` which will return the basic response.
 public class URLResponseOperation: NetworkOperation<HTTPURLResponse> {

--- a/PeakNetworkTests/NetworkTests.swift
+++ b/PeakNetworkTests/NetworkTests.swift
@@ -8,6 +8,7 @@
 
 import XCTest
 import PeakResult
+import PeakOperation
 @testable import PeakNetwork
 
 class NetworkTests: XCTestCase {
@@ -257,6 +258,86 @@ class NetworkTests: XCTestCase {
         
         networkOperation.enqueue()
         
+        waitForExpectations(timeout: 1)
+    }
+
+    
+    func testRequestableInputOperationParseSuccess() {
+        let session = MockSession { session in
+            session.queue(response: MockResponse(json: ["name" : "Sam"], statusCode: .ok))
+        }
+        
+        let expect = expectation(description: "")
+        
+        let networkOperation = RequestableInputOperation<TestEntity>(session: session)
+        networkOperation.input = Result { URLRequestable(URL(string: "http://google.com")!) }
+        
+        networkOperation.addResultBlock { result in
+            do {
+                let (entity, _) = try result.resolve()
+                XCTAssertEqual(entity.name, "Sam")
+                expect.fulfill()
+            } catch {
+                XCTFail()
+            }
+        }
+        
+        networkOperation.enqueue()
+        
+        waitForExpectations(timeout: 1)
+    }
+    
+    func testRequestableInputOperationNoInput() {
+        let session = MockSession { _ in }
+
+        let expect = expectation(description: "")
+        
+        let networkOperation = RequestableInputOperation<TestEntity>(session: session)
+
+        networkOperation.addResultBlock { result in
+            do {
+                let _ = try result.resolve()
+                XCTFail()
+            } catch {
+                switch error {
+                case ResultError.noResult:
+                    expect.fulfill()
+                default:
+                    XCTFail()
+                }
+            }
+        }
+        
+        networkOperation.enqueue()
+        waitForExpectations(timeout: 1)
+    }
+    
+    
+    func testRequestableInputOperationParseFailure() {
+        let session = MockSession { session in
+            session.queue(response: MockResponse(json: ["wrong" : "key"], statusCode: .ok))
+        }
+
+        let expect = expectation(description: "")
+
+        let networkOperation = RequestableInputOperation<TestEntity>(session: session)
+        networkOperation.input = Result { URLRequestable(URL(string: "http://google.com")!) }
+
+        networkOperation.addResultBlock { result in
+            do {
+                let _ = try result.resolve()
+                XCTFail()
+            } catch {
+                switch error {
+                case DecodingError.keyNotFound(_, _):
+                    expect.fulfill()
+                default:
+                    XCTFail()
+                }
+            }
+        }
+
+        networkOperation.enqueue()
         waitForExpectations(timeout: 1)
     }
 

--- a/PeakNetworkTests/NetworkTests.swift
+++ b/PeakNetworkTests/NetworkTests.swift
@@ -274,7 +274,7 @@ class NetworkTests: XCTestCase {
         
         networkOperation.addResultBlock { result in
             do {
-                let (entity, _) = try result.resolve()
+                let entity = try result.resolve()
                 XCTAssertEqual(entity.name, "Sam")
                 expect.fulfill()
             } catch {

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,20 +1,20 @@
 PODS:
-  - PeakOperation (2.1.0):
+  - PeakOperation (2.1.1):
     - PeakResult
-  - PeakResult (2.1.0)
+  - PeakResult (2.1.1)
 
 DEPENDENCIES:
   - PeakOperation
 
 SPEC REPOS:
-  "git@gitlab.3squared.com:iOSLibraries/CocoaPodSpecs.git":
+  https://github.com/cocoapods/specs.git:
     - PeakOperation
     - PeakResult
 
 SPEC CHECKSUMS:
-  PeakOperation: 7c2d9adcfaadc1b8c847c5a7313fd466caaec42a
-  PeakResult: 4b8d79159f0bb20dc9715c73fd4ed642c15a24ea
+  PeakOperation: 1cfae299e91470e62e871bbab8d5e8d51820ea56
+  PeakResult: a3bbeaae2485fec1199a09f6991a7b8613a9d6ed
 
-PODFILE CHECKSUM: c46eb47d18e75c37e242c41e932c7fbcdad7d38f
+PODFILE CHECKSUM: ed624724faf77626fcf2a4b39d2b800979ad8f3d
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
See #3.

Previously your Requestable had to be known at initialisation time. This adds DynamicRequestableOperation which lets you override or set a Requestable after init, and RequestableInputOperation which takes a Requestable input and executes the request.