### PR TITLE
Add InterceptorSession

### DIFF
--- a/PeakNetwork.xcodeproj/project.pbxproj
+++ b/PeakNetwork.xcodeproj/project.pbxproj
@@ -26,7 +26,7 @@
 		CB3178731FDAA5AF00B063ED /* test.json in Resources */ = {isa = PBXBuildFile; fileRef = CB3178721FDAA5AF00B063ED /* test.json */; };
 		CB3AA6CA1FD5A5C9008EFC5C /* HTTPStatusCodes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3AA6C91FD5A5C9008EFC5C /* HTTPStatusCodes.swift */; };
 		CB489E2121A57CB800569B18 /* Interceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB489E2021A57CB800569B18 /* Interceptor.swift */; };
-		CB489E2321A57DD300569B18 /* InterceptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB489E2221A57DD300569B18 /* InterceptorTests.swift */; };
+		CB489E2321A57DD300569B18 /* RequestInterceptorSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB489E2221A57DD300569B18 /* RequestInterceptorSessionTests.swift */; };
 		CB5F252A206BD4A30023FB7F /* MockSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB5F2529206BD4A30023FB7F /* MockSessionTests.swift */; };
 		CBF2179720CAC63700515DB2 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBF2179620CAC63700515DB2 /* Logger.swift */; };
 		CBFD4EE71F740C07008CD8AA /* PeakNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CBFD4EDD1F740C07008CD8AA /* PeakNetwork.framework */; };
@@ -70,7 +70,7 @@
 		CB3178721FDAA5AF00B063ED /* test.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = test.json; sourceTree = "<group>"; };
 		CB3AA6C91FD5A5C9008EFC5C /* HTTPStatusCodes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPStatusCodes.swift; sourceTree = "<group>"; };
 		CB489E2021A57CB800569B18 /* Interceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Interceptor.swift; sourceTree = "<group>"; };
-		CB489E2221A57DD300569B18 /* InterceptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterceptorTests.swift; sourceTree = "<group>"; };
+		CB489E2221A57DD300569B18 /* RequestInterceptorSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestInterceptorSessionTests.swift; sourceTree = "<group>"; };
 		CB5F2529206BD4A30023FB7F /* MockSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSessionTests.swift; sourceTree = "<group>"; };
 		CBF2179620CAC63700515DB2 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		CBFD4EDD1F740C07008CD8AA /* PeakNetwork.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PeakNetwork.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -177,7 +177,7 @@
 				CB2380F41F740D7600F1B001 /* 600.png */,
 				CB2380F21F740D7600F1B001 /* CertificatePinningTests.swift */,
 				CB5F2529206BD4A30023FB7F /* MockSessionTests.swift */,
-				CB489E2221A57DD300569B18 /* InterceptorTests.swift */,
+				CB489E2221A57DD300569B18 /* RequestInterceptorSessionTests.swift */,
 				CB2380F11F740D7600F1B001 /* github.com.cer */,
 				CB2380EE1F740D7600F1B001 /* ImageControllerTests.swift */,
 				CB2380F01F740D7600F1B001 /* NetworkTests.swift */,
@@ -386,7 +386,7 @@
 				CB2380F71F740D9C00F1B001 /* NetworkTests.swift in Sources */,
 				CB2380F51F740D9C00F1B001 /* CertificatePinningTests.swift in Sources */,
 				CB2380F61F740D9C00F1B001 /* ImageControllerTests.swift in Sources */,
-				CB489E2321A57DD300569B18 /* InterceptorTests.swift in Sources */,
+				CB489E2321A57DD300569B18 /* RequestInterceptorSessionTests.swift in Sources */,
 				CB5F252A206BD4A30023FB7F /* MockSessionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PeakNetwork.xcodeproj/project.pbxproj
+++ b/PeakNetwork.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		CB3AA6CA1FD5A5C9008EFC5C /* HTTPStatusCodes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3AA6C91FD5A5C9008EFC5C /* HTTPStatusCodes.swift */; };
 		CB489E2121A57CB800569B18 /* Interceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB489E2021A57CB800569B18 /* Interceptor.swift */; };
 		CB489E2321A57DD300569B18 /* RequestInterceptorSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB489E2221A57DD300569B18 /* RequestInterceptorSessionTests.swift */; };
+		CB489E2B21A6FB4D00569B18 /* ErrorInterceptorSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB489E2A21A6FB4D00569B18 /* ErrorInterceptorSessionTests.swift */; };
 		CB5F252A206BD4A30023FB7F /* MockSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB5F2529206BD4A30023FB7F /* MockSessionTests.swift */; };
 		CBF2179720CAC63700515DB2 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBF2179620CAC63700515DB2 /* Logger.swift */; };
 		CBFD4EE71F740C07008CD8AA /* PeakNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CBFD4EDD1F740C07008CD8AA /* PeakNetwork.framework */; };
@@ -71,6 +72,7 @@
 		CB3AA6C91FD5A5C9008EFC5C /* HTTPStatusCodes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPStatusCodes.swift; sourceTree = "<group>"; };
 		CB489E2021A57CB800569B18 /* Interceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Interceptor.swift; sourceTree = "<group>"; };
 		CB489E2221A57DD300569B18 /* RequestInterceptorSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestInterceptorSessionTests.swift; sourceTree = "<group>"; };
+		CB489E2A21A6FB4D00569B18 /* ErrorInterceptorSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorInterceptorSessionTests.swift; sourceTree = "<group>"; };
 		CB5F2529206BD4A30023FB7F /* MockSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSessionTests.swift; sourceTree = "<group>"; };
 		CBF2179620CAC63700515DB2 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		CBFD4EDD1F740C07008CD8AA /* PeakNetwork.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PeakNetwork.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -178,6 +180,7 @@
 				CB2380F21F740D7600F1B001 /* CertificatePinningTests.swift */,
 				CB5F2529206BD4A30023FB7F /* MockSessionTests.swift */,
 				CB489E2221A57DD300569B18 /* RequestInterceptorSessionTests.swift */,
+				CB489E2A21A6FB4D00569B18 /* ErrorInterceptorSessionTests.swift */,
 				CB2380F11F740D7600F1B001 /* github.com.cer */,
 				CB2380EE1F740D7600F1B001 /* ImageControllerTests.swift */,
 				CB2380F01F740D7600F1B001 /* NetworkTests.swift */,
@@ -385,6 +388,7 @@
 				CB2380F81F740D9C00F1B001 /* TestEntity.swift in Sources */,
 				CB2380F71F740D9C00F1B001 /* NetworkTests.swift in Sources */,
 				CB2380F51F740D9C00F1B001 /* CertificatePinningTests.swift in Sources */,
+				CB489E2B21A6FB4D00569B18 /* ErrorInterceptorSessionTests.swift in Sources */,
 				CB2380F61F740D9C00F1B001 /* ImageControllerTests.swift in Sources */,
 				CB489E2321A57DD300569B18 /* RequestInterceptorSessionTests.swift in Sources */,
 				CB5F252A206BD4A30023FB7F /* MockSessionTests.swift in Sources */,

--- a/PeakNetwork.xcodeproj/project.pbxproj
+++ b/PeakNetwork.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		CB2380FB1F740DBD00F1B001 /* github.com.cer in Resources */ = {isa = PBXBuildFile; fileRef = CB2380F11F740D7600F1B001 /* github.com.cer */; };
 		CB3178731FDAA5AF00B063ED /* test.json in Resources */ = {isa = PBXBuildFile; fileRef = CB3178721FDAA5AF00B063ED /* test.json */; };
 		CB3AA6CA1FD5A5C9008EFC5C /* HTTPStatusCodes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3AA6C91FD5A5C9008EFC5C /* HTTPStatusCodes.swift */; };
+		CB489E2121A57CB800569B18 /* Interceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB489E2021A57CB800569B18 /* Interceptor.swift */; };
+		CB489E2321A57DD300569B18 /* InterceptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB489E2221A57DD300569B18 /* InterceptorTests.swift */; };
 		CB5F252A206BD4A30023FB7F /* MockSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB5F2529206BD4A30023FB7F /* MockSessionTests.swift */; };
 		CBF2179720CAC63700515DB2 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBF2179620CAC63700515DB2 /* Logger.swift */; };
 		CBFD4EE71F740C07008CD8AA /* PeakNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CBFD4EDD1F740C07008CD8AA /* PeakNetwork.framework */; };
@@ -67,6 +69,8 @@
 		CB2380F41F740D7600F1B001 /* 600.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = 600.png; sourceTree = "<group>"; };
 		CB3178721FDAA5AF00B063ED /* test.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = test.json; sourceTree = "<group>"; };
 		CB3AA6C91FD5A5C9008EFC5C /* HTTPStatusCodes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPStatusCodes.swift; sourceTree = "<group>"; };
+		CB489E2021A57CB800569B18 /* Interceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Interceptor.swift; sourceTree = "<group>"; };
+		CB489E2221A57DD300569B18 /* InterceptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterceptorTests.swift; sourceTree = "<group>"; };
 		CB5F2529206BD4A30023FB7F /* MockSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSessionTests.swift; sourceTree = "<group>"; };
 		CBF2179620CAC63700515DB2 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		CBFD4EDD1F740C07008CD8AA /* PeakNetwork.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PeakNetwork.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -160,6 +164,7 @@
 				CB2380DF1F740D1500F1B001 /* Session.swift */,
 				CB3AA6C91FD5A5C9008EFC5C /* HTTPStatusCodes.swift */,
 				CBF2179620CAC63700515DB2 /* Logger.swift */,
+				CB489E2021A57CB800569B18 /* Interceptor.swift */,
 			);
 			path = PeakNetwork;
 			sourceTree = "<group>";
@@ -172,6 +177,7 @@
 				CB2380F41F740D7600F1B001 /* 600.png */,
 				CB2380F21F740D7600F1B001 /* CertificatePinningTests.swift */,
 				CB5F2529206BD4A30023FB7F /* MockSessionTests.swift */,
+				CB489E2221A57DD300569B18 /* InterceptorTests.swift */,
 				CB2380F11F740D7600F1B001 /* github.com.cer */,
 				CB2380EE1F740D7600F1B001 /* ImageControllerTests.swift */,
 				CB2380F01F740D7600F1B001 /* NetworkTests.swift */,
@@ -367,6 +373,7 @@
 				CBF2179720CAC63700515DB2 /* Logger.swift in Sources */,
 				CB2380E81F740D1500F1B001 /* Session.swift in Sources */,
 				CB2380EC1F740D1500F1B001 /* Errors.swift in Sources */,
+				CB489E2121A57CB800569B18 /* Interceptor.swift in Sources */,
 				CB3AA6CA1FD5A5C9008EFC5C /* HTTPStatusCodes.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -379,6 +386,7 @@
 				CB2380F71F740D9C00F1B001 /* NetworkTests.swift in Sources */,
 				CB2380F51F740D9C00F1B001 /* CertificatePinningTests.swift in Sources */,
 				CB2380F61F740D9C00F1B001 /* ImageControllerTests.swift in Sources */,
+				CB489E2321A57DD300569B18 /* InterceptorTests.swift in Sources */,
 				CB5F252A206BD4A30023FB7F /* MockSessionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PeakNetwork/Interceptor.swift
+++ b/PeakNetwork/Interceptor.swift
@@ -1,5 +1,5 @@
 //
-//  InterceptorSession.swift
+//  RequestInterceptorSession.swift
 //  PeakNetwork
 //
 //  Created by Sam Oakley on 21/11/2018.
@@ -10,7 +10,7 @@ import Foundation
 
 public typealias RequestInterceptor = (inout URLRequest) -> Void
 
-public class InterceptorSession: Session {
+public class RequestInterceptorSession: Session {
     
     private let session: Session
     private var interceptors: [RequestInterceptor] = []

--- a/PeakNetwork/Interceptor.swift
+++ b/PeakNetwork/Interceptor.swift
@@ -36,7 +36,6 @@ public class RequestInterceptorSession: Session {
     }
     
     public func dataTask(with request: URLRequest, completionHandler: @escaping DataTaskCompletionHandler) -> URLSessionDataTask {
-        
         var request = request
         interceptors.forEach { $0(&request) }
         

--- a/PeakNetwork/Interceptor.swift
+++ b/PeakNetwork/Interceptor.swift
@@ -1,0 +1,51 @@
+//
+//  InterceptorSession.swift
+//  PeakNetwork
+//
+//  Created by Sam Oakley on 21/11/2018.
+//  Copyright © 2018 3Squared. All rights reserved.
+//
+
+import Foundation
+
+public typealias RequestInterceptor = (inout URLRequest) -> Void
+
+public class InterceptorSession: Session {
+    
+    private let session: Session
+    private var interceptors: [RequestInterceptor] = []
+    
+    /// Create a new InterceptorSession.
+    ///
+    /// - Parameters:
+    ///   - session:
+    ///   - interceptors: An array of RequestInterceptors to execute on each request made.
+    public init(with session: Session, interceptors: [RequestInterceptor]) {
+        self.session = session
+        self.interceptors = interceptors
+    }
+    
+    /// Create a new InterceptorSession.
+    ///
+    /// - Parameters:
+    ///   - session:
+    ///   - interceptors: A RequestInterceptor to execute on each request made.
+    public init(with session: Session, interceptor: @escaping RequestInterceptor) {
+        self.session = session
+        self.interceptors = [interceptor]
+    }
+    
+    public func dataTask(with request: URLRequest, completionHandler: @escaping DataTaskCompletionHandler) -> URLSessionDataTask {
+        
+        var request = request
+        interceptors.forEach { $0(&request) }
+        
+        return session.dataTask(with: request) { data, response, error in
+            completionHandler(data, response, error)
+        }
+    }
+    
+    public func add(interceptor: @escaping RequestInterceptor) {
+        interceptors.append(interceptor)
+    }
+}

--- a/PeakNetwork/Session.swift
+++ b/PeakNetwork/Session.swift
@@ -202,6 +202,9 @@ public class MockSession: Session {
         let taskResponse: MockResponse
         let request: URLRequest
         
+        override var originalRequest: URLRequest { return request }
+        override var currentRequest: URLRequest { return request }
+
         init(_ response: MockResponse, forRequest request: URLRequest, completionHandler: @escaping DataTaskCompletionHandler) {
             self.taskResponse = response
             self.request = request

--- a/PeakNetworkTests/ErrorInterceptorSessionTests.swift
+++ b/PeakNetworkTests/ErrorInterceptorSessionTests.swift
@@ -1,0 +1,61 @@
+//
+//  ErrorInterceptorSessionTests.swift
+//  PeakNetworkTests
+//
+//  Created by Sam Oakley on 22/11/2018.
+//  Copyright © 2018 3Squared. All rights reserved.
+//
+
+import Foundation
+
+import XCTest
+@testable import PeakNetwork
+
+class ErrorInterceptorSessionTests: XCTestCase {
+    
+    func testInterceptorIsCalledForError()  {
+        let expect = expectation(description: "")
+
+        let baseSession = MockSession { session in
+            session.queue(response: MockResponse(statusCode: .internalServerError, error: TestError.justATest))
+        }
+        
+        let session = ErrorInterceptorSession(with: baseSession) { _, _, error in
+            switch (error) {
+            case TestError.justATest:
+                expect.fulfill()
+            default:
+                XCTFail()
+            }
+        }
+        
+        let request = URLRequest(url: URL(string:"http://google.com")!)
+        session.dataTask(with: request) { _, _, _ in }.resume()
+        
+        waitForExpectations(timeout: 1)
+    }
+    
+    func testInterceptorIsNotCalledForSuccessfulResponse()  {
+        let expect = expectation(description: "")
+        
+        let baseSession = MockSession { session in
+            session.queue(response: MockResponse(statusCode: .ok))
+        }
+        
+        let session = ErrorInterceptorSession(with: baseSession) { _, _, error in
+            XCTFail()
+        }
+        
+        let request = URLRequest(url: URL(string:"http://google.com")!)
+        session.dataTask(with: request) { _, _, _ in
+            expect.fulfill()
+        }.resume()
+        
+        waitForExpectations(timeout: 1)
+    }
+
+    
+    public enum TestError: Error {
+        case justATest
+    }
+}

--- a/PeakNetworkTests/InterceptorTests.swift
+++ b/PeakNetworkTests/InterceptorTests.swift
@@ -1,0 +1,71 @@
+//
+//  InterceptorTests.swift
+//  PeakNetworkTests
+//
+//  Created by Sam Oakley on 21/11/2018.
+//  Copyright © 2018 3Squared. All rights reserved.
+//
+
+import Foundation
+
+import XCTest
+@testable import PeakNetwork
+
+class InterceptorTests: XCTestCase {
+    
+    func testSingleInterceptor()  {
+        let baseSession = MockSession { session in
+            session.queue(response: MockResponse(statusCode: .ok))
+        }
+        
+        let session = InterceptorSession(with: baseSession) { request in
+            request.setValue("intercepted", forHTTPHeaderField: "request")
+        }
+        
+        let request = URLRequest(url: URL(string:"http://google.com")!)
+        let task = session.dataTask(with: request) { _, _, _ in }
+    
+        XCTAssertEqual(task.originalRequest!.value(forHTTPHeaderField: "request"), "intercepted")
+    }
+    
+    func testMultipleInterceptors()  {
+        let baseSession = MockSession { session in
+            session.queue(response: MockResponse(statusCode: .ok))
+        }
+        
+        let session = InterceptorSession(with: baseSession, interceptors: [
+            { request in
+                request.setValue("1", forHTTPHeaderField: "a")
+            },
+            { request in
+                request.setValue("2", forHTTPHeaderField: "b")
+            }
+        ])
+        
+        let request = URLRequest(url: URL(string:"http://google.com")!)
+        let task = session.dataTask(with: request) { _, _, _ in }
+        
+        XCTAssertEqual(task.originalRequest!.value(forHTTPHeaderField: "a"), "1")
+        XCTAssertEqual(task.originalRequest!.value(forHTTPHeaderField: "b"), "2")
+    }
+
+    func testAddInterceptor()  {
+        let baseSession = MockSession { session in
+            session.queue(response: MockResponse(statusCode: .ok))
+        }
+        
+        let session = InterceptorSession(with: baseSession) { request in
+            request.setValue("1", forHTTPHeaderField: "a")
+        }
+        
+        session.add { request in
+            request.setValue("2", forHTTPHeaderField: "b")
+        }
+        
+        let request = URLRequest(url: URL(string:"http://google.com")!)
+        let task = session.dataTask(with: request) { _, _, _ in }
+        
+        XCTAssertEqual(task.originalRequest!.value(forHTTPHeaderField: "a"), "1")
+        XCTAssertEqual(task.originalRequest!.value(forHTTPHeaderField: "b"), "2")
+    }
+}

--- a/PeakNetworkTests/RequestInterceptorSessionTests.swift
+++ b/PeakNetworkTests/RequestInterceptorSessionTests.swift
@@ -11,14 +11,14 @@ import Foundation
 import XCTest
 @testable import PeakNetwork
 
-class InterceptorTests: XCTestCase {
+class RequestInterceptorSessionTests: XCTestCase {
     
     func testSingleInterceptor()  {
         let baseSession = MockSession { session in
             session.queue(response: MockResponse(statusCode: .ok))
         }
         
-        let session = InterceptorSession(with: baseSession) { request in
+        let session = RequestInterceptorSession(with: baseSession) { request in
             request.setValue("intercepted", forHTTPHeaderField: "request")
         }
         
@@ -33,7 +33,7 @@ class InterceptorTests: XCTestCase {
             session.queue(response: MockResponse(statusCode: .ok))
         }
         
-        let session = InterceptorSession(with: baseSession, interceptors: [
+        let session = RequestInterceptorSession(with: baseSession, interceptors: [
             { request in
                 request.setValue("1", forHTTPHeaderField: "a")
             },
@@ -54,7 +54,7 @@ class InterceptorTests: XCTestCase {
             session.queue(response: MockResponse(statusCode: .ok))
         }
         
-        let session = InterceptorSession(with: baseSession) { request in
+        let session = RequestInterceptorSession(with: baseSession) { request in
             request.setValue("1", forHTTPHeaderField: "a")
         }
         


### PR DESCRIPTION
InterceptorSession allows requests to be manipulated at the Session level. You could use this, for example, to add headers to every request.

Added one for errors too, in case there is some global error handler you want to add for certain types of error like token expiration.